### PR TITLE
fix rscript not found issue, gzip removed for speed

### DIFF
--- a/fusion_detection.R
+++ b/fusion_detection.R
@@ -6,8 +6,9 @@ args <- commandArgs(trailingOnly = TRUE)
 genome = args[[1]]
 annotations = args[[2]]
 jaffa_results = args[[3]]
-sourceDir = args[[4]]
-source(file.path(sourceDir,"fusion_detection_functions.R"))
+# sourceDir = args[[4]]
+# source(file.path(sourceDir,"fusion_detection_functions.R"))
+source(args[[4]])
 
 cat('Load transcript sequence information')
 geneSeq <- readDNAStringSet(file=genome)

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,8 +1,21 @@
 singularity {
     enabled = true
     autoMounts = true
-    runOptions = "--bind $PWD"
+    runOptions = "--bind $PWD,/vast/scratch/users/yan.a/,$HOME"
 	singularity.envWhitelist = "JAVA_HOME"
     SINGULARITYENV_R_LIBS_USER="/usr/local/lib/R/site-library"
     SINGULARITYENV_R_ENVIRON_USER="NULL"
+}
+
+process {
+    executor = 'slurm'
+    cpus = 48
+    memory = '480 GB'
+    time = '48h'
+}
+
+report {
+    enabled  = true
+    file     = 'report2.html'
+    overwrite = true
 }


### PR DESCRIPTION
Hi Andre and Minghao,

I have tried to use your pipeline to run bambu_clump, I have noticed a few issues.

1, the flexiplex step took very long to finish, I checked the log and found most time was spent in gzip which is not paralleled. I suggest to remove this step since minimap2 can take fastq as input in the later process. This will speed up the flexiplex process. To give you an idea, your 240million PacBio data took 1.5-2hrs in barcode detention with flexiplex, 3 hours umi demux with flexiplex, but 15 hours in gzip, which also resulting minimap2 later run 18hours. (all with 48 cores).
In addition, the barcode detection can be run on a subsampled subset if the input file is too big, which could also speed up the flexiplex process.

2, Rscript in your `projectDir` is not found in your docker image, so when you call `source(script)`, it cannot find the script. I tried to adjust the mounting path, but seems still not working. This could be related to different setting of nextflow cache and working directory path on our HPC.
So, I have forked your repo and made a few edits to make the entire pipeline work at least on our HPC.

I have created a pull request for this.

Cheers,
Alex