### PR TITLE
fix pipeline to give correct number of bambu output for multi-sample analysis, tidy up some codes

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -47,7 +47,7 @@ process flexiplex{
 	tuple val(sample), path(fastq), val(chemistry), val(technology), val(whitelist)
 
 	output:
-    tuple val(sample), path("new_reads.fastq.gz"), val(chemistry), val(technology), emit: fastq
+    tuple val(sample), path("${sample}_flexiplexfilter_reads.fastq.gz"), val(chemistry), val(technology), emit: fastq
 
 	script:
 	"""	
@@ -71,8 +71,8 @@ process flexiplex{
 	    python /mnt/software/main.py --outfile my_barcode_list.txt flexiplex_barcodes_counts.txt 
         awk '{print \$1}' whitelist.txt my_barcode_list.txt | sort | uniq -d > my_filtered_barcode_list.txt
 	fi
-    flexiplex -p $params.ncore -k my_filtered_barcode_list.txt \$chem -f 8 -e $params.flexiplex_e reads.fastq > new_reads.fastq
-	gzip new_reads.fastq
+    flexiplex -p $params.ncore -k my_filtered_barcode_list.txt \$chem -f 8 -e $params.flexiplex_e reads.fastq > ${sample}_flexiplexfilter_reads.fastq
+	gzip ${sample}_flexiplexfilter_reads.fastq
     rm reads.fastq
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -494,11 +494,13 @@ workflow {
                                         row.containsKey("clusters") ? row.whitelist : params.clusters) }        
             flexiplex_out_ch = flexiplex(readsChannel.map{it[0..4]})
             minimap_out_ch = minimap(flexiplex_out_ch, ch_genome)
-            barcodeMaps = readsChannel.collect{it[6]}
+
+            whitelists = readsChannel.collect{it[4]}
+            barcodeMaps = readsChannel.collect{it[5]}
+            clusters = readsChannel.collect{it[6]}
+
             barcodeMaps2 = barcodeMaps.map { it == null ? it : params.barcodeMap }
-            whitelists = readsChannel.collect{it[5]}
             whiteLists2 = whitelists.map { it == null ? it : params.whitelist }
-            clusters = readsChannel.collect{it[7]}
             clusters2 = clusters.map { it == null ? it : params.clusters }
         }
         else {  

--- a/main.nf
+++ b/main.nf
@@ -86,7 +86,7 @@ process minimap{
 	
 	input: 
 	tuple val(sample),path(newfastq), val(chemistry), val(technology)
-	path(genome)
+	each path(genome)
 
 	output: 
 	tuple val(sample), path ('*.demultiplexed.bam') 
@@ -492,7 +492,6 @@ workflow {
                                         row.containsKey("whitelist") ? row.whitelist : params.whitelist,
                                         row.containsKey("barcode_map") ? row.barcode_map :  params.barcodeMap,
                                         row.containsKey("clusters") ? row.whitelist : params.clusters) }        
-            
             flexiplex_out_ch = flexiplex(readsChannel.map{it[0..4]})
             minimap_out_ch = minimap(flexiplex_out_ch, ch_genome)
             barcodeMaps = readsChannel.collect{it[6]}

--- a/main.nf
+++ b/main.nf
@@ -200,7 +200,7 @@ process bambu{
     se = bambu(reads = readClassFile, annotations = extendedAnno, genome = "$genome", ncore = $params.ncore, discovery = FALSE, quant = FALSE, demultiplexed = TRUE, verbose = FALSE, opt.em = list(degradationBias = FALSE), assignDist = TRUE, spatial = spatial)
     saveRDS(se, paste0(runName, "_quantData.rds"))
     for(se.x in se){
-        if(as.logical("$params.processByBam")){
+        if(length(metadata(se.x)[['sampleNames']]) == 1){
             writeBambuOutput(se.x, '.', prefix = metadata(se.x)\$sampleNames)
         } else{
             writeBambuOutput(se.x, '.', prefix = "combined_")


### PR DESCRIPTION
Current multi-sample analysis do not give the expected number of bambu outputs based on the number of samples. 

- In minimap, multi-sample fastq from flexiplex outputs and a genome path is provided as input. But, minimap only runs on one sample because genome path is a single-length vector. Now fixed in [534c953](https://github.com/GoekeLab/bambu-singlecell-spatial/pull/15/commits/534c9539d1c08f380933a40eae7c3cc999169e57) that runs minimap in parallel depending on the number of input samples.
- `processByBam` performs read class construction on separate samples when set to TRUE, but the default is FALSE. So, bambu always writes `combined_` output when providing read class files as input. Now fixed in [f64a831](https://github.com/GoekeLab/bambu-singlecell-spatial/pull/15/commits/f64a83183d2bcb298b0a86f723d3ad7b32fba4d1)
- tidy code and change output names of flexiplex in [5f99e54](https://github.com/GoekeLab/bambu-singlecell-spatial/pull/15/commits/5f99e54fcf7e1d5d0e5ac134a895f7c914280027) and [8860282](https://github.com/GoekeLab/bambu-singlecell-spatial/pull/15/commits/88602821beb2debbb4b9f6db2d86cba6906d7242)